### PR TITLE
Complete lumen to complex apps readiness

### DIFF
--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -251,13 +251,14 @@
     "packages/cli": {
       "name": "@lumen/cli",
       "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^5.5.0"
-      },
-      "peerDependencies": {
+      "dependencies": {
+        "@lumen/core-ir": "^0.1.0",
         "@lumen/fmt": "^0.1.0",
         "@lumen/parser": "^0.1.0",
         "@lumen/runner": "^0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0"
       }
     },
     "packages/core-ir": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -262,13 +262,14 @@
     "packages/cli": {
       "name": "@lumen/cli",
       "version": "0.1.0",
-      "devDependencies": {
-        "typescript": "^5.5.0"
-      },
-      "peerDependencies": {
+      "dependencies": {
+        "@lumen/core-ir": "^0.1.0",
         "@lumen/fmt": "^0.1.0",
         "@lumen/parser": "^0.1.0",
         "@lumen/runner": "^0.1.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0"
       }
     },
     "packages/core-ir": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,10 +9,10 @@
     "test": "echo \"(stub) no tests yet\" && exit 0"
   },
   "dependencies": {
-    "@lumen/core-ir": "workspace:*",
-    "@lumen/parser": "workspace:*",
-    "@lumen/fmt": "workspace:*",
-    "@lumen/runner": "workspace:*"
+    "@lumen/core-ir": "^0.1.0",
+    "@lumen/parser": "^0.1.0",
+    "@lumen/fmt": "^0.1.0",
+    "@lumen/runner": "^0.1.0"
   },
   "devDependencies": {
     "typescript": "^5.5.0"

--- a/packages/core-ir/src/ast.ts
+++ b/packages/core-ir/src/ast.ts
@@ -64,7 +64,8 @@ function nodeSignature(e: Expr): string {
     case 'Let': return `Let:${e.name}:${(e.expr as any).sid ?? '?'}`
     case 'Fn': {
       const eff = Array.from(e.effects.values()).sort().join('|')
-      return `Fn:${e.name ?? ''}(${e.params.join(',')}):${(e.body as any).sid ?? '?'}:${eff}`
+      const paramsSig = (e.params as Array<{ name: string, type?: string }>).map(p => `${p.name}:${p.type ?? ''}`).join('|')
+      return `Fn:${e.name ?? ''}(${paramsSig}):${(e.body as any).sid ?? '?'}:${eff}`
     }
     case 'Call': return `Call:${(e.callee as any).sid ?? '?'}(${e.args.map(a => (a as any).sid ?? '?').join(',')})`
     case 'Binary': return `Binary:${e.op}:${(e.left as any).sid ?? '?'}:${(e.right as any).sid ?? '?'}`
@@ -91,12 +92,19 @@ export function assignStableSids(e: Expr): void {
   switch (e.kind) {
     case 'Program': for (const d of e.decls) assignStableSids(d); break
     case 'Let': assignStableSids(e.expr); break
+    case 'Assign': assignStableSids(e.expr); break
     case 'Fn': assignStableSids(e.body); break
     case 'Call': assignStableSids(e.callee); for (const a of e.args) assignStableSids(a); break
     case 'Binary': assignStableSids(e.left); assignStableSids(e.right); break
+    case 'Block': for (const s of e.stmts) assignStableSids(s); break
     case 'EffectCall': for (const a of e.args) assignStableSids(a); break
     case 'ActorDecl': assignStableSids(e.body); break
+    case 'ActorDeclNew':
+      for (const s of e.state) assignStableSids(s.init as any)
+      for (const h of e.handlers as any[]) { if (h.pattern) assignStableSids(h.pattern); if (h.guard) assignStableSids(h.guard); if (h.body) assignStableSids(h.body) }
+      break
     case 'Send': assignStableSids(e.actor); assignStableSids(e.message); break
+    case 'Ask': assignStableSids(e.actor); assignStableSids(e.message); break
     default: break
   }
   const sig = nodeSignature(e)


### PR DESCRIPTION
Refine SID hashing for full determinism and fix workspace dependency resolution.

The `sid-stability` test was failing due to incomplete SID generation for `Fn` nodes (missing parameter types/names) and insufficient traversal for `Assign`, `Block`, `ActorDeclNew`, and `Ask` nodes. Additionally, `workspace:*` dependencies in `packages/cli` prevented successful `npm install`. These changes ensure a stable and deterministic baseline for further development.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ea5f16c-24a4-4771-b88c-5513a89b3cc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ea5f16c-24a4-4771-b88c-5513a89b3cc2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

